### PR TITLE
Cmdlet Improvements

### DIFF
--- a/ChromeBackup.psm1
+++ b/ChromeBackup.psm1
@@ -2,42 +2,47 @@
 # Next, Save this file in that folder with the title ChromeBookmarkBackup.psm1
 # Now you should be able to open a powershell window and just type "Backup-ChromeBookmark" and you will have a backup located in "C:\ChromeBookmarksBackup"
 
-function Backup-ChromeBookmarks {
-    # This is currently the default path for Chrome bookmarks. Can be edited if Google updates the default location. Pulls the username from the environment variable.
-    $filePath = "C:\Users\$($env:UserName)\AppData\Local\Google\Chrome\User Data\Default\bookmarks"
+Function Backup-ChromeBookmarks {
+    [CmdletBinding()]
+    Param (
+        # This is currently the default path for Chrome bookmarks. Can be edited if Google updates the default location. Pulls the username from the environment variable.
+        [Parameter(
+            Position=0)]
+        [string] $BookmarkPath = "C:\Users\$($env:UserName)\AppData\Local\Google\Chrome\User Data\Default\bookmarks",
 
-    # This is the folder that the bookmarks are moved to. 
-    $backupFilePath = "C:\ChromeBookmarksBackup"
+        # This is the folder that the bookmarks are moved to. 
+        [Parameter(
+            Position=1)]
+        [string] $DestinationFolderPath = "C:\ChromeBookmarksBackup"
+    )
 
-    # This builds the file name with the current date. Have to change the format that Get-Date outputs so it doesn't have a ':' in it which is not allowed in paths.
-    $destinationFileName = "$(Get-Date -Format o | ForEach-Object { $_ -replace ":", "." }) Bookmarks"
+    # This builds the file name with the current date. Have to change the format that Get-Date outputs with ForEach-Object because some characters are not allowed in paths.
+    [string] $destinationFileName = "$(Get-Date -Format "dd/MM/yyyy HH:mm" | ForEach-Object { $_ -replace ":", "." } | ForEach-Object { $_ -replace "/", "." }) Bookmarks"
 
-    # This is complete file path of the new bookmarks file.
-    $destinationPath = ($($backupFilePath) + '\' + $($destinationFileName))
+    # This joins the file name we generated with the path that was input by the user.
+    [string] $destinationPath = ($($DestinationFolderPath) + '\' + $($destinationFileName))
 
-    # Checks for the destination folder, and creates it if it doesn't fine it initially. Loops back on itself until it is validated.
+    # Checks for the destination folder and if it can't find it, it creates it. Then it loops back to the validation again. 
     [bool] $destinationPathValidated = $false
     Do {
-        Write-Output "Testing Destination Path...`n"
-        if (Get-Item -Path $backupFilePath) {
+        Write-Verbose "Testing Destination Path."
+        If (Test-Path -Path $DestinationFolderPath) {
             $destinationPathValidated = $true
-            Write-Output "Destination path found at: $($backupFilePath)`n"
-        } else {
-            Write-Output "Destination path not found. Creating destination folder at: $($backupFilePath) `n"
-            New-Item -Path "C:\" -Name "ChromeBookmarksBackup" -ItemType "directory" -Force
+            Write-Verbose "Destination path found at: $($DestinationFolderPath)"
+        } Else {
+            Write-Verbose "Destination path not found. Creating destination folder at: $($DestinationFolderPath)"
+            New-Item -Path $($DestinationFolderPath) -ItemType "directory" -Force
         }
     } While ($destinationPathValidated = $false)
 
     # Checks for the Bookmarks file and begins the copy. Does validation and lets user know if it worked or not. Closes program either way.
-    if (Get-Item -Path $filePath) {
-        Copy-Item -Path $filePath -Destination $destinationPath
-        If (Get-Item -Path $destinationPath) {
-            Write-Output "Backup Successful.`n"
+    If (Get-Item -Path $BookmarkPath) {
+        Copy-Item -Path $BookmarkPath -Destination $destinationPath
+        If (Test-Path -Path $destinationPath) {
+            Write-Verbose "Backup Successful."
         }
-        Read-Host -Prompt "Backup Process has finished. Press Enter to close."
-    } else {
-        Write-Output "Could not find the bookmarks file. It is possible Google has moved the file after an update.`n"
-        Read-Host -Prompt "Verify Chrome is not open and try running the backup script again. Press Enter to close."
+        Write-Output "Backup Process has completed."
+    } Else {
+        Write-Output "Could not find the source bookmarks file. Verify it is in $($BookmarkPath) and try again."
     }
-    Exit
 }


### PR DESCRIPTION
Added the option for the user to pass a bookmark path and/or destination folder path to the command to change the file that is being backed up or to change where it is backed up to. 
Changed most of the output text to verbose so running the command only tells you success or failure now.
Simplified failure output text.
Changed format of the time in the output file to be more user-friendly.
Cleaned up the New-Item command that creates the backup folder.
Formatted function names to standard case.
Replaced conditional use of Get-Item with Test-Path which does not produce an error message when it evaluates to false.